### PR TITLE
fix(render): set attributes syntax for different types than string

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -5,7 +5,7 @@ import type { VueRenderer } from '@storybook/vue3'
 
 export const renderWithSlots = <TRenderer extends Renderer, TArgs extends Record<string, any>>() => {
   const makeComponentTemplate = (component: string, slots: string, args: Args) => `
-    <${component} ${Object.entries(args).map(([key, value]) => `${key}="${value}"`).join(" ")}>
+    <${component} ${Object.entries(args).map(([key, value]) => `${typeof value === "string" ? key : ":" + key}="${value}"`).join(" ")}>
       ${slots}
     </${component}>
   ` as const


### PR DESCRIPTION
As mentioned in https://github.com/JoJk0/storybook-addon-vue-slots/issues/8#issuecomment-1805666408 , this plugin add all component props as string and omit attribute syntax for Boolean, Object, Array, etc.