### PR TITLE
fix(render): properly handle non-string args

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -5,7 +5,11 @@ import type { VueRenderer } from '@storybook/vue3'
 
 export const renderWithSlots = <TRenderer extends Renderer, TArgs extends Record<string, any>>() => {
   const makeComponentTemplate = (component: string, slots: string, args: Args) => `
-    <${component} ${Object.entries(args).map(([key, value]) => `${typeof value === "string" ? key : ":" + key}="${value}"`).join(" ")}>
+    <${component} ${Object.entries(args).map(([key, value]) =>
+      typeof value === "string"
+          ? `${key}="${value}"`
+          : `:${key}='${JSON.stringify(value)}'`
+    ).join(" ")}>
       ${slots}
     </${component}>
   ` as const


### PR DESCRIPTION
This PR attempts to solve the problem reported in https://github.com/JoJk0/storybook-addon-vue-slots/issues/8

It has been tested, and works, in a project I work with for a customer. (Unfortunately not open, so I can't share the repo.) Hopefully the diff is reasonably self-explanatory.