### PR TITLE
fix(render): better fix for bound args

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -5,11 +5,7 @@ import type { VueRenderer } from '@storybook/vue3'
 
 export const renderWithSlots = <TRenderer extends Renderer, TArgs extends Record<string, any>>() => {
   const makeComponentTemplate = (component: string, slots: string, args: Args) => `
-    <${component} ${Object.entries(args).map(([key, value]) =>
-      typeof value === "string"
-          ? `${key}="${value}"`
-          : `:${key}='${JSON.stringify(value)}'`
-    ).join(" ")}>
+    <${component} ${Object.keys(args).map((key) => `:${key}="args.${key}"`).join(" ")}>
       ${slots}
     </${component}>
   ` as const


### PR DESCRIPTION
A better fix for the bound variables, that makes sure we can interactively edit the args in the storybook controls. It also still shows the args separately in the story's code preview (as was the point of PR 4).

Edit: Has been tested with Storybook 7.6.0